### PR TITLE
Adding more details for edge case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2023-06-05
+### Changed
+- Changed wording in logging output for the edge case scenario where an Activation Lock is detected but it cannot find a user with an associated FindMy token.
+
 ## [1.5.1] - 2023-03-01
 ### Changed
 - Fixed applescript dialog to resolve issue where it would not execute in certain situations.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ I've set the FindMy icon as the default, since that helps the end-user visually 
   * Alternatively, if you have configured your MDM to `Allowed user-based Activation Lock', then activation lock will become active again once they turn Find My mac back on.
 * Why didn't you just use `nvram fmm-mobileme-token-FMM` to determine Activation Lock status?
   * That reports on whether FindMy is enabled, regardless of actual Activation Lock status.
+* The script says the device is still activation locked but can't find any users with Find My enabled.
+  * There are edge cases where this can occur. In instances where an activation lock is enabled and a user DOES have Find My enabled, it typically resolves itself eventually. There are rare instances where a user doesn't have a FindMy status written to their `MobileMeAccounts.plist` when the script runs.
+  * Another scenario that can occur is the user logs out of iCloud but the activation lock isn't successfully removed. In this scenario you can end up with a device where activation lock is enabled but there's no currently logged in user with Find My enabled. You can work around this by logging into another iCloud account and logging back out.
+  * Keep in mind that the source of truth for Activation Lock status lives on Apple's servers. This script is leveraging a cached version of that status locally, but there are edge cases where that cached status can be incorrect resulting in unexpected behavior.
   
 ## What's Next?
 * I've added everything I've wanted to see so far. Anything else you want to see in the next version? Weird Activation Lock edge cases? Let me know!

--- a/unActivationLock.zsh
+++ b/unActivationLock.zsh
@@ -10,8 +10,8 @@
 ########################################################################################
 # Created by Brian Van Peski - macOS Adventures
 ########################################################################################
-# Current version: 1.5.1 | See CHANGELOG for full version history.
-# Updated: 03/01/2023
+# Current version: 1.5.2 | See CHANGELOG for full version history.
+# Updated: 06/05/2023
 
 # Set logging - Send logs to stdout as well as Unified Log
 # Use 'log show --process "logger"'to view logs activity.
@@ -131,8 +131,12 @@ elif [[ $activationLock == "Enabled" ]]; then
     LOGGING "Activation Lock Status: $activationLock"
     exit 0
     elif [[ $activationLock == "Enabled" && -z $FindMyUser ]]; then
-      LOGGING "Activation lock status is $activationLock, and there are no users with a FindMy token associated. Something is wonky..."
-      #I don't think this can happen, but leaving it here just in case.
+      if /usr/sbin/nvram -xp | grep fmm-mobileme-token-FMM > /dev/null 2>&1; then
+        FindMyMac="Enabled"
+      else
+        FindMyMac="Disabled"
+      fi
+      LOGGING "--- Activation lock status is $activationLock, and there are no users with a FindMy token associated. FindMyMac is $FindMyMac on this computer. The cached activation lock status or FindMy status in the user's MobileMeAccounts.plist may be incorrect. Alerting admin for further troubleshooting..."
       exit 1
     else
       LOGGING "--- The currently logged in user: '$currentUser' is not the user associated with the Activation Lock.


### PR DESCRIPTION
Adding a little more clarity in the logging for an edge case where a device may be activation locked, but the script can't find a user with a FindMy status associated with it. In this case, it typically resolves itself once that value gets written, or you can reach out to the user directly and tell them to log out after receiving the error in your MDM console.

I COULD default to just attempting to prompt the current user, but this is is more of an edge case I'd be worried about causing additional false positives.