### PR TITLE
V1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.2] - 2023-06-05
+## v 1.6 | 2023-12-21
 ### Changed
-- Changed wording in logging output for the edge case scenario where an Activation Lock is detected but it cannot find a user with an associated FindMy token.
+`CHANGED` -  Modified all open and osascript commands to run as the currently logged in user to catch edge cases where the `open` command failed to open System Settings.
 
-## [1.5.1] - 2023-03-01
+## v 1.5.2 | 2023-06-05
 ### Changed
-- Fixed applescript dialog to resolve issue where it would not execute in certain situations.
+`CHANGED` - Changed wording in logging output for the edge case scenario where an Activation Lock is detected but it cannot find a user with an associated FindMy token.
 
-## [1.5] - 2023-02-01
+## v 1.5.1 | 2023-03-01
+### Changed
+`CHANGED` - Fixed applescript dialog to resolve issue where it would not execute in certain situations.
+
+## v 1.5 | 2023-02-01
+`ADDED` - Added ability to always prompt user to log out of Find My regardless of activation lock status.
+
+`ADDED` - Script now grabs the iCloud email address of the user who activation locked the device.
+
+`ADDED` - Added user input for sleep timer between prompts.
+
+`ADDED` - Added user input for number of attempts to make before giving up.
+
+`ADDED` - Added System Settings activate command to account for edge cases where System Settings would launch behind other windows.
+
+`ADDED` - Added SwiftDialog support (Thanks to Trevor Sysock @BigMacAdmin)
+### Changed
+`CHANGED` - Changed open url to open directly to the iCloud portion of AppleID. This is using a deprecate url scheme and will probably stop working on the next major version of macOS. (thanks @kspitzer14)
+
+`CHANGED` - Changed default icon to FindMy.icns
+
+`CHANGED` - Changed timeout from number of seconds to number of attempts.
+
+## v 1.4 | 2023-01-22
+`CHANGED` -  Cleaned up LOGGING for better legibility.
+
+## v 1.3 | 2023-01-18
+`CHANGED` - Updated dialog with new icon (Thanks to Trevor Sysock @BigMacAdmin)
+
+## v 1.2 | 2022-10-22
+`ADDED` - Added graceful exit if current user is not associated with lock.
+
+`ADDED` - Added activation lock user lookup for scenarios where a machine may have more than one local user.
+
+## v 1.0 | 2022-08-11
 ### Added
-- Added ability to always prompt user to log out of Find My regardless of activation lock status.
-- Script now grabs the iCloud email address of the user who activation locked the device.
-- Added user input for sleep timer between prompts.
-- Added user input for number of attempts to make before giving up.
-- Added System Settings activate command to account for edge cases where System Settings would launch behind other windows.
-- Added SwiftDialog support (Thanks to Trevor Sysock @BigMacAdmin)
-### Changed
-- Changed open url to open directly to the iCloud portion of AppleID. This is using a deprecate url scheme and will probably stop working on the next major version of macOS. (thanks @kspitzer14)
-- Changed default icon to FindMy.icns
-- Changed timeout from number of seconds to number of attempts.
-
-## [1.4] - 2023-01-22
-### Changed
-- Cleaned up LOGGING for better legibility.
-
-## [1.3] - 2023-01-18
-### Changed
-- Updated dialog with new icon (Thanks to Trevor Sysock @BigMacAdmin)
-
-## [1.2] - 2022-10-22
-### Added
-- Added graceful exit if current user is not associated with lock.
-- Added activation lock user lookup for scenarios where a machine may have more than one local user.
-
-## [1.0] - 2022-08-11
-### Added
-- First go at a solution for solving activation lock issues.
+`ADDED` - First go at a solution for solving activation lock issues.

--- a/unActivationLock.zsh
+++ b/unActivationLock.zsh
@@ -25,7 +25,7 @@ function LOGGING {
 ##############################################################
 # Messaging
 dialogTitle="Turn off Find My Mac"
-dialogMessage="This company device is currently locked to your iCloud account. Please turn off Find My Mac under iCloud > Find My Mac."
+dialogMessage="This company device is currently locked to your iCloud account. Please turn off Find My Mac under iCloud > Show More Apps > Find My Mac."
 appIcon="/System/Library/PrivateFrameworks/AOSUI.framework/Versions/A/Resources/findmy.icns" #Path to app icon for messaging (optional)
 # SwiftDialog Options
 swiftDialogOptions=(

--- a/unActivationLock.zsh
+++ b/unActivationLock.zsh
@@ -10,8 +10,8 @@
 ########################################################################################
 # Created by Brian Van Peski - macOS Adventures
 ########################################################################################
-# Current version: 1.5.2 | See CHANGELOG for full version history.
-# Updated: 06/05/2023
+# Current version: 1.6 | See CHANGELOG for full version history.
+# Updated: 12/21/2023
 
 # Set logging - Send logs to stdout as well as Unified Log
 # Use 'log show --process "logger"'to view logs activity.
@@ -44,7 +44,8 @@ DisallowFindMy=false
 ##############################################################
 # VARIABLES & FUNCTIONS
 ##############################################################
-currentUser=$(ls -la /dev/console | awk '{print $3}')
+currentUser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }' )
+uid=$(id -u "$currentUser")
 activationLock=$(/usr/sbin/system_profiler SPHardwareDataType | awk '/Activation Lock Status/{print $NF}')
 plist="/Users/$currentUser/Library/Preferences/MobileMeAccounts.plist"
 DEPStatus=$(profiles status -type enrollment | grep "Enrolled via DEP" | awk '{print $4}')
@@ -53,6 +54,17 @@ KandjiAgent="/Library/Kandji/Kandji Agent.app"
 #Path to SwiftDialog
 dialogPath="/usr/local/bin/dialog"
 dialogApp="/Library/Application Support/Dialog/Dialog.app"
+
+runAsUser() {
+  # From https://scriptingosx.com/2020/08/running-a-command-as-another-user
+  if [ "$currentUser" != "loginwindow" ]; then
+    launchctl asuser "$uid" sudo -u "$currentUser" "$@"
+  else
+    echo "No user logged in"
+    # Uncomment the exit command to make the function exit with an error when no user is logged in
+    # exit 1
+  fi
+}
 
 UserLookup (){
 ## Fetch all local user accounts, return account with iCloud FindMyStatus enabled.
@@ -92,10 +104,10 @@ UserDialog (){
     "$dialogPath" --title "$dialogTitle" --message "$dialogMessage" ${swiftDialogOptions[@]} ${iconCMD[@]}
   #No Kandji and no SwiftDialog, default to osascript w/ icon.
   elif [ -e "$appIcon" ]; then
-    /usr/bin/osascript -e 'display dialog "'"$dialogMessage"'" with title "'"$dialogTitle"'" with icon POSIX file "'"$appIcon"'" buttons {"Okay"} default button 1 giving up after 15'
+    runAsUser /usr/bin/osascript -e 'display dialog "'"$dialogMessage"'" with title "'"$dialogTitle"'" with icon POSIX file "'"$appIcon"'" buttons {"Okay"} default button 1 giving up after 15'
   #No Kandji, no SwiftDialog, and no appicon. Use osascript.
   else
-    /usr/bin/osascript -e 'display dialog "'"$dialogMessage"'" with title "'"$dialogTitle"'" buttons {"Okay"} default button 1 giving up after 15'
+    runAsUser /usr/bin/osascript -e 'display dialog "'"$dialogMessage"'" with title "'"$dialogTitle"'" buttons {"Okay"} default button 1 giving up after 15'
   fi
 }
 
@@ -122,7 +134,7 @@ elif [[ $activationLock == "Enabled" ]]; then
         fi
         LOGGING "--- Found logged in iCloud account '$FindMyUser'... Presenting pane to user and requesting user to log out..."
         open "x-apple.systempreferences:com.apple.preferences.AppleIDPrefPane?iCloud"
-        osascript -e 'tell application "System Settings"' -e 'activate' -e 'end tell'
+        runAsUser osascript -e 'tell application "System Settings"' -e 'activate' -e 'end tell'
         UserDialog
         sleep $wait_time
         ((dialogAttempts++))
@@ -157,8 +169,8 @@ else
         exit 1
         fi
         LOGGING "--- Found logged in iCloud account for user '$FindMyUser' with account '$FindMyEmail'... Presenting pane to user and requesting user to log out of Find My Mac."
-        open "x-apple.systempreferences:com.apple.preferences.AppleIDPrefPane?iCloud"
-        osascript -e 'tell application "System Settings"' -e 'activate' -e 'end tell'
+        runAsUser open "x-apple.systempreferences:com.apple.preferences.AppleIDPrefPane?iCloud"
+        runAsUser osascript -e 'tell application "System Settings"' -e 'activate' -e 'end tell'
         UserDialog
         sleep $wait_time
         ((dialogAttempts++))


### PR DESCRIPTION
`CHANGED` - Modified all open and osascript commands to run as the currently logged in user to catch edge cases where the `open` command failed to open System Settings.
`CHANGED` - Modified default user messaging to reflect new "Show more apps" in Sonoma